### PR TITLE
add script to run jest coverage for one file

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "start:mock": "cross-env API_ENV=mock craco start & mock-server",
     "build": "craco build",
     "test": "craco test",
+    "jestc": "run(){ target=$(echo $1 | sed -E 's/.(spec|test)(.[jt]s)$/\\2*/'); npm test -- $1 --watchAll=false --coverage --collectCoverageFrom=$target; }; run",
     "eject": "react-scripts eject",
     "prepare": "husky install",
     "webp": "sh webp.sh",

--- a/src/pages/no-match/index.test.js
+++ b/src/pages/no-match/index.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react'
+import NoMatch from './index'
+
+test('renders 404', () => {
+  render(<NoMatch />)
+  const noMatchEle = screen.getByText(/404/)
+  expect(noMatchEle).toBeInTheDocument()
+})


### PR DESCRIPTION
`npm run jestc src/pages/no-match/index.test.js` will become `craco test "src/pages/no-match/index.test.js" "--watchAll=false" "--coverage" "--collectCoverageFrom=src/pages/no-match/index.js*"`, note that it will only collect coverage from `src/pages/no-match/index.js*`.

When you want to improve coverage, this script will be helpful.